### PR TITLE
Update Poisson solve to accept arbitrary eigenvalues

### DIFF
--- a/src/ParticleInCell.jl
+++ b/src/ParticleInCell.jl
@@ -44,7 +44,7 @@ end
 export step!
 
 include("field_utils.jl")
-export FiniteDifferenceToEdges, AverageEdgesToNodes
+export FiniteDifferenceToEdges, AverageEdgesToNodes, ZeroField, MultiplyField
 
 include("poisson.jl")
 export PoissonSolveFFT

--- a/src/field_utils.jl
+++ b/src/field_utils.jl
@@ -68,3 +68,10 @@ struct ZeroField{F} <: AbstractSimulationStep
 end
 
 step!(step::ZeroField) = step.field.values .= 0
+
+struct MultiplyField{F,T} <: AbstractSimulationStep
+    field::F
+    x::T
+end
+
+step!(step::MultiplyField) = step.field.values .*= step.x

--- a/src/interpolation.jl
+++ b/src/interpolation.jl
@@ -163,6 +163,16 @@ struct BSplineChargeInterpolation{S,F,IF} <: AbstractSimulationStep
             interp_func,
         )
     end
+
+    function BSplineChargeInterpolation(
+        species::S,
+        rho::Field{T,N,NodeOffset},
+        interp_width,
+        interp_func::F,
+    ) where {T,N,S,F}
+
+        new{S,typeof(rho),F}(species, rho, -1, interp_width, interp_func)
+    end
 end
 
 function step!(step::BSplineChargeInterpolation)

--- a/src/particle_updaters/electrostatic.jl
+++ b/src/particle_updaters/electrostatic.jl
@@ -56,7 +56,7 @@ function step!(step::ElectrostaticParticlePush)
         )
 
         for I in Is
-            grid_cell_coord = cell_index_to_cell_coords(step.E, I)
+            grid_cell_coord = cell_index_to_cell_coords(step.E, I, 1)
             dist = Tuple(particle_cell_coord .- grid_cell_coord)
             interp_weights = step.interpolation_function.(dist)
             interp_weight = prod(interp_weights)

--- a/src/poisson.jl
+++ b/src/poisson.jl
@@ -51,3 +51,64 @@ function step!(step::PoissonSolveFFT)
     inv(step.fft_plan) * step.ft_vector
     view(step.phi.values, eachindex(step.phi)) .= real.(step.ft_vector)
 end
+
+struct PoissonSolveFFT5{T,D,G,P,F<:AbstractField} <: AbstractSimulationStep
+    rho::F
+    phi::F
+
+    Ksq_inv::Array{T,D}
+    ft_vector::Array{Complex{T},D}
+
+    fft_plan::P
+
+    function PoissonSolveFFT5(rho::F, phi::F) where {T,D,G,F<:AbstractField{T,D,G}}
+        # This restriction could possibly be relaxed to just require compatible grids...
+        @assert rho.grid === phi.grid
+        # Currently only supports periodic boundary conditions...
+        @assert all(rho.grid.periodic)
+        @assert num_elements(rho) == 1 && num_elements(phi) == 1
+
+        epsilon_0 = 8.8541878128e-12
+        # Ksq_inv = reshape(copy(rho.values), size(rho.values)[1:end-1]...)
+        Ksq_inv = zeros(T, rho.grid.num_cells...)
+        ft_vector = zeros(Complex{T}, rho.grid.num_cells...)
+
+        grid = rho.grid
+        # TODO: Make this use the cell_lengths logic in Grid
+        sim_lengths = grid.upper_bounds .- grid.lower_bounds
+        cell_lengths = sim_lengths ./ grid.num_cells
+        for I in eachindex(Ksq_inv)
+            It = Tuple(I)
+
+            if any(x -> x == 1, It)
+                Ksq_inv[I] = 0
+                continue
+            end
+
+            # ks = 2π .* (It .- 1) ./ sim_lengths
+            ks =
+                2π .*
+                ifelse.(It .<= size(Ksq_inv) ./ 2, It .- 1, It .- size(Ksq_inv) .- 1) ./
+                sim_lengths
+            inv_Ksqs =
+                (
+                    ks .^ 2 .* sinc.(ks .* cell_lengths ./ 2 ./ pi) .^ 2 .*
+                    (2 .+ cos.(ks .* cell_lengths)) ./ 3
+                ) .^ (-1) ./ epsilon_0
+
+            Ksq_inv[I] = prod(inv_Ksqs)
+        end
+
+        fft_plan = plan_fft!(ft_vector)
+
+        new{T,D,G,typeof(fft_plan),F}(rho, phi, Ksq_inv, ft_vector, fft_plan)
+    end
+end
+
+function step!(step::PoissonSolveFFT5)
+    step.ft_vector .= view(step.rho.values, eachindex(step.rho))
+    step.fft_plan * step.ft_vector
+    step.ft_vector .= step.ft_vector .* step.Ksq_inv
+    inv(step.fft_plan) * step.ft_vector
+    view(step.phi.values, eachindex(step.phi)) .= real.(step.ft_vector)
+end

--- a/src/poisson.jl
+++ b/src/poisson.jl
@@ -1,3 +1,7 @@
+field_solve_three_pt(k, dx) = k^2 * sinc(k * dx / 2 / pi)^2
+field_solve_lagrange(k, dx) = k^2 * sinc(k * dx / 2 / pi)^2 * (2 + cos(k * dx)) / 3
+field_solve_five_pt(k, dx) = -1 * k^2 * sinc(k * dx / 2 / pi)^2 * (-7 + cos(k * dx)) / 6
+
 struct PoissonSolveFFT{T,D,G,P,F<:AbstractField} <: AbstractSimulationStep
     rho::F
     phi::F
@@ -7,61 +11,11 @@ struct PoissonSolveFFT{T,D,G,P,F<:AbstractField} <: AbstractSimulationStep
 
     fft_plan::P
 
-    function PoissonSolveFFT(rho::F, phi::F) where {T,N,O,D,G,F<:AbstractField{T,N,O,D,G}}
-        # This restriction could possibly be relaxed to just require compatible grids...
-        @assert rho.grid === phi.grid
-        # Currently only supports periodic boundary conditions...
-        @assert all(rho.grid.periodic)
-        @assert num_elements(rho) == 1 && num_elements(phi) == 1
-
-        epsilon_0 = 8.8541878128e-12
-        # Ksq_inv = reshape(copy(rho.values), size(rho.values)[1:end-1]...)
-        Ksq_inv = zeros(T, rho.grid.num_cells...)
-        ft_vector = zeros(Complex{T}, rho.grid.num_cells...)
-
-        grid = rho.grid
-        # TODO: Make this use the cell_lengths logic in Grid
-        sim_lengths = grid.upper_bounds .- grid.lower_bounds
-        cell_lengths = sim_lengths ./ grid.num_cells
-        for I in eachindex(Ksq_inv)
-            It = Tuple(I)
-
-            if any(x -> x == 1, It)
-                Ksq_inv[I] = 0
-                continue
-            end
-
-            ks = 2π .* (It .- 1) ./ sim_lengths
-            grid_angles = ks .* cell_lengths ./ 2
-            inv_Ksqs = (cell_lengths ./ (2 .* sin.(grid_angles))) .^ 2 ./ epsilon_0
-
-            Ksq_inv[I] = prod(inv_Ksqs)
-        end
-
-        fft_plan = plan_fft!(ft_vector)
-
-        new{T,D,G,typeof(fft_plan),F}(rho, phi, Ksq_inv, ft_vector, fft_plan)
-    end
-end
-
-function step!(step::PoissonSolveFFT)
-    step.ft_vector .= view(step.rho.values, eachindex(step.rho))
-    step.fft_plan * step.ft_vector
-    step.ft_vector .= step.ft_vector .* step.Ksq_inv
-    inv(step.fft_plan) * step.ft_vector
-    view(step.phi.values, eachindex(step.phi)) .= real.(step.ft_vector)
-end
-
-struct PoissonSolveFFT5{T,D,G,P,F<:AbstractField} <: AbstractSimulationStep
-    rho::F
-    phi::F
-
-    Ksq_inv::Array{T,D}
-    ft_vector::Array{Complex{T},D}
-
-    fft_plan::P
-
-    function PoissonSolveFFT5(rho::F, phi::F) where {T,D,G,F<:AbstractField{T,D,G}}
+    function PoissonSolveFFT(
+        rho::F,
+        phi::F,
+        k2s = field_solve_three_pt,
+    ) where {T,D,G,F<:AbstractField{T,D,G}}
         # This restriction could possibly be relaxed to just require compatible grids...
         @assert rho.grid === phi.grid
         # Currently only supports periodic boundary conditions...
@@ -90,11 +44,7 @@ struct PoissonSolveFFT5{T,D,G,P,F<:AbstractField} <: AbstractSimulationStep
                 2π .*
                 ifelse.(It .<= size(Ksq_inv) ./ 2, It .- 1, It .- size(Ksq_inv) .- 1) ./
                 sim_lengths
-            inv_Ksqs =
-                (
-                    ks .^ 2 .* sinc.(ks .* cell_lengths ./ 2 ./ pi) .^ 2 .*
-                    (2 .+ cos.(ks .* cell_lengths)) ./ 3
-                ) .^ (-1) ./ epsilon_0
+            inv_Ksqs = (k2s.(ks, cell_lengths)) .^ (-1) ./ epsilon_0
 
             Ksq_inv[I] = prod(inv_Ksqs)
         end
@@ -105,7 +55,7 @@ struct PoissonSolveFFT5{T,D,G,P,F<:AbstractField} <: AbstractSimulationStep
     end
 end
 
-function step!(step::PoissonSolveFFT5)
+function step!(step::PoissonSolveFFT)
     step.ft_vector .= view(step.rho.values, eachindex(step.rho))
     step.fft_plan * step.ft_vector
     step.ft_vector .= step.ft_vector .* step.Ksq_inv

--- a/src/simulation.jl
+++ b/src/simulation.jl
@@ -17,7 +17,7 @@ function create_electrostatic_simulation(
     sim = Simulation(AbstractSimulationStep[])
 
     # Create fields
-    lower_guard_cells = div(interpolation_order, 2)
+    lower_guard_cells = div(interpolation_order, 2) + 1
     rho = Field(grid, NodeOffset(), V, lower_guard_cells)
     phi = Field(grid, NodeOffset(), V, lower_guard_cells)
     Eedge = Field(grid, EdgeOffset(), V, lower_guard_cells)

--- a/src/simulation.jl
+++ b/src/simulation.jl
@@ -17,7 +17,7 @@ function create_electrostatic_simulation(
     sim = Simulation(AbstractSimulationStep[])
 
     # Create fields
-    lower_guard_cells = div(interpolation_order, 2) + 1
+    lower_guard_cells = div(interpolation_order, 2)
     rho = Field(grid, NodeOffset(), V, lower_guard_cells)
     phi = Field(grid, NodeOffset(), V, lower_guard_cells)
     Eedge = Field(grid, EdgeOffset(), V, lower_guard_cells)


### PR DESCRIPTION
- add five pt stencil poisson solve
- add MultiplyField step
- reduce number of guard cells in simulation creation helper function
- add ability to create interpolation with an arbitrary shape function
- refactor poisson solve to allow for arbitrary eigenvalues
- temporarily use first dimension for calculating E field location
