### PR TITLE
Switch position and momentum updates to make particle push symplectic

### DIFF
--- a/src/particle_updaters/electrostatic.jl
+++ b/src/particle_updaters/electrostatic.jl
@@ -38,14 +38,6 @@ function step!(step::ElectrostaticParticlePush)
     species = step.species
 
     for n in eachindex(species)
-        # Push the particle based on its current velocity
-        particle_position!(
-            species,
-            n,
-            particle_position(species, n) .+
-            (step.timestep / particle_mass(species, n)) .* particle_momentum(species, n),
-        )
-
         # Accelerate the particle according to E
         # Find which cell the particle is in, and create a CartesianIndices
         # object that extends +/- interpolation_width in all directions
@@ -68,5 +60,13 @@ function step!(step::ElectrostaticParticlePush)
                 step.E.values[I],
             )
         end
+
+        # Push the particle based on its current velocity
+        particle_position!(
+            species,
+            n,
+            particle_position(species, n) .+
+            (step.timestep / particle_mass(species, n)) .* particle_momentum(species, n),
+        )
     end
 end

--- a/src/particle_updaters/electrostatic_test.jl
+++ b/src/particle_updaters/electrostatic_test.jl
@@ -15,6 +15,6 @@
     dt = 1.0
     step = ElectrostaticParticlePush(species, E, dt)
     step!(step)
-    @test species.positions[1][1] == 0.5
+    @test species.positions[1][1] == 0.6
     @test species.momentums[1][1] == 0.1
 end


### PR DESCRIPTION
The momentum update needs to use fields that are consistant with the
current particle locations. This requires updating the momentum first,
and then using this new momentum to push the particles.

Essentially, the update is now
p_(n - 1/2) -> p_(n + 1/2)
x_n -> x_(n + 1)

I am currently being pretty sloppy with the half timestep momentums, but
that should probably be fixed in the future.
